### PR TITLE
Wechat news msg type notification supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,12 +56,14 @@ v2.0.0 版本现已支持 Jellyfin Server！！！详细配置请参看章节 [J
 
 端口：8000
 
+<mark>Telegram、WeChat、Bark 三种通知方式至少配置一种。</mark>
+
 | 参数 | 要求 | 说明 |
 | -- | -- | -- |
 | TMDB_API_TOKEN | 必须 | TMDB API 读访问令牌（API Read Access Token） |
 | TVDB_API_KEY | 可选 | Your TVDB API Key |
-| TG_BOT_TOKEN | 必须 | Your Telegram Bot Token |
-| TG_CHAT_ID | 必须 | Your Telegram Channel's Chat ID |
+| TG_BOT_TOKEN | 可选 | Your Telegram Bot Token |
+| TG_CHAT_ID | 可选 | Your Telegram Channel's Chat ID |
 | LOG_LEVEL | 可选 | 日志等级 [DEBUG, INFO, WARNING] 三个等级，默认 INFO|
 | LOG_EXPORT | 可选 | 日志写文件标志 [True, False] 是否将日志输出到文件，默认 False|
 | LOG_PATH | 可选 | 日志文件保存路径，默认 /var/tmp/emby_notifier_tg |
@@ -101,9 +103,9 @@ services:
       # 这里所有的环境变量都不要使用引号
       # 必填参数
       - TMDB_API_TOKEN=<Your TMDB API Token>
+      # 可选参数
       - TG_BOT_TOKEN=<Your Telegram Bot Tokne>
       - TG_CHAT_ID=<Your Telegram Channel's Chat ID>
-      # 可选参数
       - TVDB_API_KEY=<Your TVDB API Key>
       - LOG_LEVEL=INFO # [DEBUG, INFO, WARNING] 三个等级，默认 INFO
       - LOG_EXPORT=False # [True, False0] 是否将日志输出到文件，默认 False
@@ -112,6 +114,7 @@ services:
       - WECHAT_CORP_SECRET=xxxxxx # 企业微信：应用凭证秘钥
       - WECHAT_AGENT_ID=xxxxx # 企业微信：应用 agentid
       - WECHAT_USER_ID=xxxxxx # 企业微信：用户 id，不设置时默认为 “@all”
+      - WECHAT_MSG_TYPE=news_notice  # 企业微信：消息类型，支持 news/news_notice，不设置默认为 news_notice
     network_mode: "bridge"
     ports:
       - "8000:8000"

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ v2.0.0 版本现已支持 Jellyfin Server！！！详细配置请参看章节 [J
 | WECHAT_CORP_SECRET | 可选 | （企业微信）应用的凭证秘钥 |
 | WECHAT_AGENT_ID | 可选 | （企业微信）应用 agentid |
 | WECHAT_USER_ID | 可选 | （企业微信）用户 id，默认为“@all” |
+| WECHAT_MSG_TYPE | 可选 | （企业微信）消息类型，支持图文类型（news）与模板卡片（news_notice），默认模板卡片 |
 | BARK_SERVER | 可选 | bark 服务地址，默认为公共服务器：https://api.day.app |
 | BARK_DEVICE_KEYS | 可选 | bark 设备密钥，支持设置多个设备密钥，用逗号分隔。e.g. "abcdefqweqwe,qwewqeqeqw,qweqweqweq,qweqweqwe" |
 

--- a/bark.py
+++ b/bark.py
@@ -10,7 +10,7 @@ import log
 BARK_SERVER = os.getenv("BARK_SERVER", "https://api.day.app")
 # single or multiple device keys, separated by commas
 # e.g. "abcdefqweqwe,qwewqeqeqw,qweqweqweq,qweqweqwe"
-BARK_DEVICE_KEYS = os.getenv("BARK_DEVICE_KEYS")
+BARK_DEVICE_KEYS = os.getenv("BARK_DEVICE_KEYS", "")
 BARK_DEVICE_KEYS = BARK_DEVICE_KEYS.split(",")
 
 def send_message(content: dict):

--- a/media.py
+++ b/media.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 # -*- coding: UTF-8 -*-
-
+import os
 import abc, json, time
 import my_utils, tmdb_api, tvdb_api, tgbot
 import log
@@ -178,7 +178,7 @@ class Episode(IMedia):
         log.logger.debug(self.info_)
 
     def get_details(self):
-        if "Tvdb" in self.info_["ProviderIds"]:
+        if "Tvdb" in self.info_["ProviderIds"] and not os.getenv("TVDB_API_KEY") is None:
             tvdb_id, err = tvdb_api.get_seriesid_by_episodeid(self.info_["ProviderIds"]["Tvdb"])
             if err:
                 log.logger.warn(err)

--- a/sender.py
+++ b/sender.py
@@ -87,45 +87,60 @@ class WechatAppSender(MessageSender):
         wxapp.send_text(test_content)
 
     def send_media_details(self, media: dict):
-        card_details = {
-            "card_type": "news_notice",
-            "source": {
-                "icon_url": f"https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/{media.get('server_type', 'Emby').lower()}.png",
-                "desc": f"{media.get('server_type')} Server",
-                "desc_color": 0,
-            },
-            "main_title": {
-                "title": f"#{media.get('server_name')} 影视更新",
-            },
-            "card_image": {
-                "url": f"{media.get('media_backdrop') if media.get('media_type') == 'Movie' else media.get('media_still')}",
-                "aspect_ratio": 2.25,
-            },
-            "vertical_content_list": [
-                {
-                    "title": f"[{'电影' if media.get('media_type') == 'Movie' else '剧集'}] {media.get('media_name')} ({media.get('media_rel')[:4]})"
-                    + (
-                        f" 第 {media.get('tv_season')} 季 | 第 {media.get('tv_episode')} 集"
-                        if media.get("media_type") == "Episode"
-                        else ""
-                    ),
-                    "desc": f"{media.get('media_intro')}",
-                }
-            ],
-            "horizontal_content_list": [
-                {"keyname": "上映日期", "value": f"{media.get('media_rel')}"},
-                {"keyname": "评分", "value": f"{media.get('media_rating')}"},
-            ],
-            "jump_list": [
-                {
-                    "type": 1,
-                    "url": f"{media.get('media_tmdburl')}",
-                    "title": "TMDB",
+        msgtype = os.getenv("WECHAT_MSG_TYPE", "news_notice")
+        if msgtype == "news_notice":
+            card_details = {
+                "card_type": "news_notice",
+                "source": {
+                    "icon_url": f"https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/{media.get('server_type', 'Emby').lower()}.png",
+                    "desc": f"{media.get('server_type')} Server",
+                    "desc_color": 0,
                 },
-            ],
-            "card_action": {"type": 1, "url": f"{media.get('server_url')}"},
-        }
-        wxapp.send_news_notice(card_details)
+                "main_title": {
+                    "title": f"#{media.get('server_name')} 影视更新",
+                },
+                "card_image": {
+                    "url": f"{media.get('media_backdrop') if media.get('media_type') == 'Movie' else media.get('media_still')}",
+                    "aspect_ratio": 2.25,
+                },
+                "vertical_content_list": [
+                    {
+                        "title": f"[{'电影' if media.get('media_type') == 'Movie' else '剧集'}] {media.get('media_name')} ({media.get('media_rel')[:4]})"
+                        + (
+                            f" 第 {media.get('tv_season')} 季 | 第 {media.get('tv_episode')} 集"
+                            if media.get("media_type") == "Episode"
+                            else ""
+                        ),
+                        "desc": f"{media.get('media_intro')}",
+                    }
+                ],
+                "horizontal_content_list": [
+                    {"keyname": "上映日期", "value": f"{media.get('media_rel')}"},
+                    {"keyname": "评分", "value": f"{media.get('media_rating')}"},
+                ],
+                "jump_list": [
+                    {
+                        "type": 1,
+                        "url": f"{media.get('media_tmdburl')}",
+                        "title": "TMDB",
+                    },
+                ],
+                "card_action": {"type": 1, "url": f"{media.get('server_url')}"},
+            }
+            wxapp.send_news_notice(card_details)
+        elif msgtype == "news":
+            article = {
+                "title" : f"[影视更新][{'电影' if media.get('media_type') == 'Movie' else '剧集'}] {media.get('media_name')} ({media.get('media_rel')[:4]})"
+                            + (
+                                f" 第 {media.get('tv_season')} 季 | 第 {media.get('tv_episode')} 集"
+                                if media.get("media_type") == "Episode"
+                                else ""
+                            ),
+                "description" : f"{media.get('media_intro')}",
+                "url" : f"{media.get('media_tmdburl')}",
+                "picurl" : f"{media.get('media_backdrop') if media.get('media_type') == 'Movie' else media.get('media_still')}"
+            }
+            wxapp.send_news(article)
 
 
 class BarkSender(MessageSender):

--- a/sender.py
+++ b/sender.py
@@ -199,7 +199,7 @@ class SenderManager:
 
         bark_server = os.getenv("BARK_SERVER")
         bark_device_keys = os.getenv("BARK_DEVICE_KEYS")
-        log.logger.error(f"bark_server: {bark_server}, bark_device_keys: {bark_device_keys}")
+        log.logger.debug(f"bark_server: {bark_server}, bark_device_keys: {bark_device_keys}")
         if bark_server and bark_device_keys:
             self.senders.append(BarkSender())
 

--- a/wxapp.py
+++ b/wxapp.py
@@ -138,6 +138,32 @@ def send_markdown(content):
         raise e
 
 
+def send_news(article):
+    payload = {
+        "touser": USER_ID,
+        "agentid": AGENT_ID,
+        "msgtype": "news",
+        "news": {
+            "articles": [article]    
+        }
+    }
+    log.logger.debug(log.SensitiveData(json.dumps(payload, ensure_ascii=False)))
+
+    send_msg_url = SEND_MSG_URL + get_access_token()
+    try:
+        res = requests.post(send_msg_url, json=payload)
+        res.raise_for_status()
+        if res.json()["errcode"] != 0:
+            raise Exception(f"Send news failed. {res.text}")
+        log.logger.debug(f"Send news successful. Response: {res.json()}")
+    except requests.exceptions.ConnectionError as e:
+        log.logger.error(f"Send news failed. Check network connection: {e}")
+        raise e
+    except Exception as e:
+        log.logger.error(f"Send news failed. Error: {e}")
+        raise e
+
+
 def send_news_notice(card_detail):    
     payload = {
         "touser": USER_ID,


### PR DESCRIPTION
1. 微信添加图文类型消息支持，通过 WECHAT_MSG_TYPE 环境变量配置，默认为 news_notice 类型（图文消息类型虽然内容不如模板卡片丰富但微信插件可接收此类消息）；
2. 修复 TVDB_API_KEY 与 BARK_DEVICE_KEYS 不配置时日志中报错的问题；
3. 完善 Readme 变量说明，TG 参数改为可选项并作出说明；